### PR TITLE
Remove Contact Page Section from Footer of All Pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -170,7 +170,6 @@ function App() {
         </main>
 
         {/* Footer always visible */}
-        <Footer />
         <Foot />
         <BackToTop />
       </div>

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import "./Contact.css";
+import Footer from "./Footer";
 
 const Contact = () => {
   const [formData, setFormData] = useState({
@@ -40,6 +41,7 @@ const Contact = () => {
   };
 
   return (
+    <div>
     <div className="contact-wrapper">
       <div className="floating-ring ring1"></div>
       <div className="floating-ring ring2"></div>
@@ -101,6 +103,9 @@ const Contact = () => {
           </>
         )}
       </div>
+    </div>
+
+    <Footer />
     </div>
   );
 };


### PR DESCRIPTION
### Description:
This PR removes the duplicate Contact page section that was mistakenly included in the footer of all pages. The footer is now simplified and only contains the intended footer content.

### Fixes: #59 

### Changes Made:
Removed the embedded Contact page content from the footer component.
Verified that the footer layout and styling remain consistent across all pages.