### PR TITLE
Added enhancement in streak button in dark mode

### DIFF
--- a/heatmap-demo.html
+++ b/heatmap-demo.html
@@ -167,7 +167,7 @@ ui-polish
         .heatmap-day {
             width: 60px;
             height: 60px;
-
+        
         .footer {
             background: rgba(255, 255, 255, 0.1);
             backdrop-filter: blur(10px);
@@ -212,12 +212,13 @@ ui-polish
 
         .footer-elements a button:active {
             transform: translateY(0);
- main
+main
         }
         .day-label {
             font-size: 0.75rem;
         }
     }
+
  ui-polish
     @media (max-width: 480px) {
         .heatmap-day {
@@ -226,7 +227,7 @@ ui-polish
         }
         .day-label {
             font-size: 0.7rem;
-
+        
 
         @media (max-width: 480px) {
             .heatmap-day {

--- a/src/App.css
+++ b/src/App.css
@@ -7,7 +7,7 @@ body {
 }
 
 .app-container.dark {
-  background-color: #121212; /* Slightly softer than pure black */
+  background-color: #121212; /*Slightly softer than pure black*/
   color: #f0f0f0;
 }
 

--- a/src/components/TrackerCard.js
+++ b/src/components/TrackerCard.js
@@ -139,6 +139,7 @@ function TrackerCard({
             padding: "2px 6px",
             borderRadius: "12px",
             backgroundColor: currentStreak > 0 ? "rgba(255,100,100,0.2)" : "#e5e7eb",
+            color: currentStreak > 0 ? "tomato" : "#6b7280",
             fontWeight: currentStreak > 0 ? "600" : "400",
           }}
         >
@@ -149,7 +150,7 @@ function TrackerCard({
             fontSize: "0.85rem",
             padding: "2px 6px",
             borderRadius: "12px",
-            backgroundColor: "#e5e7eb",
+            backgroundColor: "rgba(255,215,0,0.2)",
           }}
         >
           🏆 {t("Best Streak")}: {bestStreak}


### PR DESCRIPTION
Added color visibility in the streak buttons at the home page in dark mode and light mode.

This is now looks like this-

<img width="1895" height="792" alt="Screenshot 2025-08-28 210338" src="https://github.com/user-attachments/assets/b2a62f69-7769-4390-adcc-00304e50d4d0" />

@Riti2407 Please check and merge this PR.
