### PR TITLE
Fix: Removed all duplicate routes, keeping only the versions that properly pass the darkMode prop to components that need it.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -251,18 +251,9 @@ function App() {
                 />
               }
             />
-            <Route path="/About" element={<About />} />
-            <Route path="/About" element={<About  darkMode = {darkMode}/>} />
-            
-            <Route path="/contact" element={<Contact />} />
-
-
+            <Route path="/About" element={<About darkMode={darkMode} />} />
             <Route path="/contact" element={<Contact darkMode={darkMode} />} />
-
-            <Route path="/login" element={<Login /> } />
-
             <Route path="/login" element={<Login />} />
-
             <Route path="/signup" element={<Signup />} />
 
           </Routes>


### PR DESCRIPTION

the problem was three routes were defined twice each:

/About route appeared on lines 254 & 255
/contact route appeared on lines 257 & 260
/login route appeared on lines 262 & 264
The duplicate definitions were dead code. The second definitions would always override the first, wasting processing and causing confusion.

Fix: Removed all duplicate routes, keeping only the versions that properly pass the darkMode prop to components that need it.
i hope this counts as a meaningful pr